### PR TITLE
Small fix in fish_finger.properties

### DIFF
--- a/assets/minecraft/mcpatcher/cit/food/fish_finger.properties
+++ b/assets/minecraft/mcpatcher/cit/food/fish_finger.properties
@@ -1,4 +1,4 @@
 type=item
 texture=fish_finger.png
-items=minecraft:cooked_fished
+items=minecraft:cooked_fish
 nbt.display.Name=Fish Finger


### PR DESCRIPTION
This small typo caused the item to show up with it's default texture.
